### PR TITLE
Only output strati VTK when required instead of every timestep, with ASPECT numbering

### DIFF
--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -36,6 +36,7 @@ module FastScapeContext
   double precision, dimension(:,:), allocatable :: mwrec,mlrec
   character(:), allocatable :: ffoldername
   integer :: kk, iistep
+  logical :: produce_output_now
 
   contains
 
@@ -51,6 +52,7 @@ module FastScapeContext
     timeStrati = 0.
     timeMarine = 0.
     timeUplift = 0.
+    produce_output_now = .false.
 
   end subroutine Init
 
@@ -836,7 +838,7 @@ module FastScapeContext
         if (((step+1)/nfreqref)*nfreqref.eq.(step+1)) ireflector = ireflector + 1
         call Strati (b, Fmix, nx, ny, xl, yl, reflector, nreflector, ireflector, step + 1, &
         fields, nfield, vexref, dt*nfreqref, stack, rec, length, sealevel, &
-        ffoldername, kk, iistep)
+        ffoldername, kk, iistep, produce_output_now)
       endif
 
     end subroutine run_Strati

--- a/src/Folder_output.f90
+++ b/src/Folder_output.f90
@@ -1,4 +1,4 @@
-subroutine Folder_output (k, istep, foldername)
+subroutine Folder_output (k, istep, foldername, produce_output)
 
 
     use FastScapeContext
@@ -6,11 +6,14 @@ subroutine Folder_output (k, istep, foldername)
 
     integer, intent(in) :: k, istep
     character(len=k), intent(in) :: foldername
+    integer, intent(in) :: produce_output
 
 
     ffoldername = foldername
     kk = k
     iistep = istep
+    produce_output_now = .false.
+    if (produce_output.eq.1) produce_output_now = .true.
 
 
     return

--- a/src/Strati.f90
+++ b/src/Strati.f90
@@ -1,5 +1,5 @@
 subroutine Strati (b,F,nx,ny,xl,yl,reflector,nreflector,ireflector,istep,fields,nfield,vex,dt, &
-  stack,rec,length,sealevel, ffoldername, kk, iistep)
+  stack,rec,length,sealevel, ffoldername, kk, iistep, produce_output_now)
 
   ! this routine tracks information (fields) on a set of reflectors (reflector)
   ! and outputs it to a set of VTKs.
@@ -14,6 +14,7 @@ subroutine Strati (b,F,nx,ny,xl,yl,reflector,nreflector,ireflector,istep,fields,
   character*30 names(nfield)
   integer :: kk, iistep
   character(len=kk), intent(in) :: ffoldername
+  logical :: produce_output_now
 
 
   double precision, dimension(:), allocatable :: s,dist
@@ -71,18 +72,21 @@ subroutine Strati (b,F,nx,ny,xl,yl,reflector,nreflector,ireflector,istep,fields,
     write (ref,'(i3)') i
     if (i.lt.10) ref(1:2)='00'
     if (i.lt.100) ref(1:1)='0'
-    call VTK_strati (reflector(:,i),'Horizon'//ref//'-',nfield,fields(:,1:nfield,i),names, nx,ny,dx,dy,istep,vex,&
-                                                                       ffoldername,kk,iistep)
+    if (produce_output_now .eqv. .TRUE.) call VTK_strati (reflector(:,i),'Horizon'//ref//'-',nfield,fields(:,1:nfield,i),names, nx,&
+                                                          ny,dx,dy,&
+                                                          istep,vex,ffoldername,kk,iistep)
   enddo
 
   call distance_to_shore (b,dist,nx,ny,rec,xl,yl)
-  call VTK_filled_strati (b, nreflector, reflector, nfield, fields, names, nx, ny, dx, dy, istep, vex, dist,&
-                         ffoldername,kk,iistep)
+  if (produce_output_now .eqv. .TRUE.) call VTK_filled_strati (b, nreflector, reflector, nfield, fields, names, nx,&
+                                                               ny, dx, dy, istep,&
+                                                               vex, dist,ffoldername,kk,iistep)
 
   deallocate (s,dist)
 
-  if (ireflector.eq.nreflector) call VTK_CUBE_strati (fields, nx, ny, nfield, nreflector, xl, yl, names,&
-      ffoldername, kk, iistep)
+  if (ireflector.eq.nreflector .AND. produce_output_now .eqv. .TRUE.) call VTK_CUBE_strati (fields, nx, ny, nfield,&
+                                 nreflector, xl, yl,&
+                                 names,ffoldername, kk, iistep)
 
   return
 

--- a/src/Strati.f90
+++ b/src/Strati.f90
@@ -64,7 +64,7 @@ subroutine Strati (b,F,nx,ny,xl,yl,reflector,nreflector,ireflector,istep,fields,
   names(5) = '5.DepositionalBathymetry(m)'
   names(6) = '6.DepositionalSlope(Deg)'
   names(7) = '7.DistanceToShore(m)'
-  names(8) = '8.Sand/ShaleRatio'
+  names(8) = '8.SiltFraction'
   names(9) = '9.ReflectorAge(yr)'
   names(10) = 'A.ThicknessErodedBelow(m)'
 

--- a/src/VTK_strati.f90
+++ b/src/VTK_strati.f90
@@ -17,13 +17,13 @@ subroutine VTK_strati (h,name,nf,f,fname,nx,ny,dx,dy,istep,vex,ffoldername,kk,ii
 
     namel = sum(len_trim(fname(:)))
 
-    write (cstep,'(i7)') istep
-    if (istep.lt.10) cstep(1:6)='000000'
-    if (istep.lt.100) cstep(1:5)='00000'
-    if (istep.lt.1000) cstep(1:4)='0000'
-    if (istep.lt.10000) cstep(1:3)='000'
-    if (istep.lt.100000) cstep(1:2)='00'
-    if (istep.lt.1000000) cstep(1:1)='0'
+    write (cstep,'(i7)') iistep
+    if (iistep.lt.10) cstep(1:6)='000000'
+    if (iistep.lt.100) cstep(1:5)='00000'
+    if (iistep.lt.1000) cstep(1:4)='0000'
+    if (iistep.lt.10000) cstep(1:3)='000'
+    if (iistep.lt.100000) cstep(1:2)='00'
+    if (iistep.lt.1000000) cstep(1:1)='0'
 
     !if (nf.gt.10) stop 'too many fields to be displayed by VTK, maximum is 10'
     !  do i=1,nf
@@ -162,13 +162,13 @@ subroutine VTK_filled_strati (basement, nreflector, reflector, nfield, fields, n
 
   write (*,*) 'Name vtk filled stratigraphy: ',ffoldername
 
-  write (cstep,'(i7)') istep
-  if (istep.lt.10) cstep(1:6)='000000'
-  if (istep.lt.100) cstep(1:5)='00000'
-  if (istep.lt.1000) cstep(1:4)='0000'
-  if (istep.lt.10000) cstep(1:3)='000'
-  if (istep.lt.100000) cstep(1:2)='00'
-  if (istep.lt.1000000) cstep(1:1)='0'
+  write (cstep,'(i7)') iistep
+  if (iistep.lt.10) cstep(1:6)='000000'
+  if (iistep.lt.100) cstep(1:5)='00000'
+  if (iistep.lt.1000) cstep(1:4)='0000'
+  if (iistep.lt.10000) cstep(1:3)='000'
+  if (iistep.lt.100000) cstep(1:2)='00'
+  if (iistep.lt.1000000) cstep(1:1)='0'
 
   iunit=30
 

--- a/src/VTK_strati.f90
+++ b/src/VTK_strati.f90
@@ -69,7 +69,7 @@ subroutine VTK_strati (h,name,nf,f,fname,nx,ny,dx,dy,istep,vex,ffoldername,kk,ii
     +nf*(npart1+npart2+4*nn)+namel,convert='big_endian')
     write (77,rec=1) &
     header(1:nheader), &
-    ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(h(i,j)*vex),i=1,nx),j=1,ny), &
+    ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(h(i,j)*abs(vex)),i=1,nx),j=1,ny), &
     footer(1:nfooter), &
     part1(1:npart1)//'H'//part2(1:npart2),sngl(h), &
     (part1(1:npart1)//trim(fname(k))//part2(1:npart2),sngl(f(:,:,k)),k=1,nf)
@@ -195,15 +195,14 @@ name='Strati-'
   write(iunit,'(a)')'ASCII'
   write(iunit,'(a)')'DATASET UNSTRUCTURED_GRID'
   write(iunit,'(a7,i10,a6)')'POINTS ',nnode,' float'
-
   do k = 0, nreflector
     do j = 1, ny
       do i = 1, nx
         ij = (j - 1)*nx + i
         if (k.eq.0) then
-          write(iunit,'(3f16.4)') dx*(i - 1), dy*(j - 1), basement(ij)*vex
+          write(iunit,'(3f16.4)') dx*(i - 1), dy*(j - 1), basement(ij)*abs(vex)
         else
-          write(iunit,'(3f16.4)') dx*(i - 1), dy*(j - 1), reflector(ij, k)*vex
+          write(iunit,'(3f16.4)') dx*(i - 1), dy*(j - 1), reflector(ij, k)*abs(vex)
         endif
       enddo
     enddo
@@ -247,16 +246,16 @@ name='Strati-'
           ij = (j - 1)*nx + i
           if (k.eq.0) then
             if (l.eq.1.or.l.eq.2) then
-              write(iunit,'(e10.4)') fields(ij,l,k+1)
+              write(iunit,'(e10.4)') min(max(1e-30,fields(ij,l,k+1)),1e30)
             elseif (l.eq.7) then
-              write(iunit,'(e10.4)') distb(ij)
+              write(iunit,'(e10.4)') min(max(1e-30,distb(ij)),1e30)
             elseif (l.eq.9) then
-              write(iunit,'(e10.4)') 2*fields(ij,l,k+1)-fields(ij,l,k+2)
+              write(iunit,'(e10.4)') min(max(1e-30,2.*fields(ij,l,k+1)-fields(ij,l,k+2)),1e30)
             else
               write(iunit,'(e10.4)') 0.
             endif
           else
-            write(iunit,'(e10.4)') fields(ij,l,k)
+             write(iunit,'(e10.4)') min(max(1e-30,fields(ij,l,k)),1e30)
           endif
         enddo
       enddo


### PR DESCRIPTION
Get a parameter from ASPECT that tells FastScape to output Stratigraphy vtks or not. At the moment, vtks are produced every ASPECT timestep. 

Also, when vtks are produced, use the ASPECT timestep in the vtk name, not the FastScape timestep. 

NB The changes I made over the last few days need to be optimized/cleaned up. This can be done once we're convinced we can use the Stratigraphy module. 